### PR TITLE
Filter finish options based on available finishes for selected printing

### DIFF
--- a/backend/app/services/card_printings_service.rb
+++ b/backend/app/services/card_printings_service.rb
@@ -165,7 +165,8 @@ class CardPrintingsService
       set_name: card["set_name"],
       collector_number: card["collector_number"],
       image_url: extract_image_url(card),
-      released_at: card["released_at"]
+      released_at: card["released_at"],
+      finishes: card["finishes"]
     }
   end
 

--- a/backend/test/services/card_printings_service_test.rb
+++ b/backend/test/services/card_printings_service_test.rb
@@ -111,6 +111,109 @@ class CardPrintingsServiceTest < ActiveSupport::TestCase
     assert_equal "2020-09-25", result[:released_at]
   end
 
+  # ---------------------------------------------------------------------------
+  # Issue #138: Include finishes array from Scryfall API
+  # ---------------------------------------------------------------------------
+  test "includes finishes array in printing data when present" do
+    card_id = "test-card-id"
+    prints_search_uri = "https://api.scryfall.com/cards/search?q=test"
+
+    # Stub card endpoint
+    card_response = {
+      "id" => card_id,
+      "prints_search_uri" => prints_search_uri
+    }
+    stub_scryfall_card_request(card_id, card_response)
+
+    # Stub prints search with cards that have finishes array
+    response = {
+      "object" => "list",
+      "has_more" => false,
+      "data" => [
+        {
+          "id" => "nonfoil-only",
+          "name" => "Test Card",
+          "set" => "znr",
+          "set_name" => "Zendikar Rising",
+          "collector_number" => "42",
+          "image_uris" => { "normal" => "https://example.com/nonfoil.jpg" },
+          "released_at" => "2020-09-25",
+          "finishes" => ["nonfoil"]
+        },
+        {
+          "id" => "both-finishes",
+          "name" => "Test Card",
+          "set" => "m21",
+          "set_name" => "Core Set 2021",
+          "collector_number" => "100",
+          "image_uris" => { "normal" => "https://example.com/both.jpg" },
+          "released_at" => "2020-07-03",
+          "finishes" => ["nonfoil", "foil"]
+        },
+        {
+          "id" => "all-finishes",
+          "name" => "Test Card",
+          "set" => "mh2",
+          "set_name" => "Modern Horizons 2",
+          "collector_number" => "200",
+          "image_uris" => { "normal" => "https://example.com/all.jpg" },
+          "released_at" => "2021-06-18",
+          "finishes" => ["nonfoil", "foil", "etched"]
+        }
+      ]
+    }
+    stub_prints_search_request(prints_search_uri, response)
+
+    service = CardPrintingsService.new(card_id: card_id)
+    results = service.call
+
+    assert_equal 3, results.size
+
+    # Results are sorted newest first (mh2, znr, m21)
+    assert_equal ["nonfoil", "foil", "etched"], results[0][:finishes]
+    assert_equal ["nonfoil"], results[1][:finishes]
+    assert_equal ["nonfoil", "foil"], results[2][:finishes]
+  end
+
+  test "handles missing finishes array gracefully" do
+    card_id = "no-finishes-card"
+    prints_search_uri = "https://api.scryfall.com/cards/search?q=test"
+
+    # Stub card endpoint
+    card_response = {
+      "id" => card_id,
+      "prints_search_uri" => prints_search_uri
+    }
+    stub_scryfall_card_request(card_id, card_response)
+
+    # Card without finishes array (should default to empty array or nil)
+    response = {
+      "object" => "list",
+      "has_more" => false,
+      "data" => [
+        {
+          "id" => "no-finishes-id",
+          "name" => "Old Card",
+          "set" => "lea",
+          "set_name" => "Alpha",
+          "collector_number" => "1",
+          "image_uris" => { "normal" => "https://example.com/old.jpg" },
+          "released_at" => "1993-08-05"
+          # No finishes array
+        }
+      ]
+    }
+    stub_prints_search_request(prints_search_uri, response)
+
+    service = CardPrintingsService.new(card_id: card_id)
+    results = service.call
+
+    assert_equal 1, results.size
+    # When finishes is missing, it should be nil or empty array
+    assert results.first[:finishes].nil? || results.first[:finishes].empty?,
+      "Expected finishes to be nil or empty when not present in API response"
+  end
+
   test "sorts printings by release date, newest first" do
     card_id = "multi-printing-card"
     prints_search_uri = "https://api.scryfall.com/cards/search?q=test"

--- a/frontend/src/lib/components/PrintingModal.finish-filtering.test.ts
+++ b/frontend/src/lib/components/PrintingModal.finish-filtering.test.ts
@@ -1,0 +1,628 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
+import PrintingModal from './PrintingModal.svelte';
+import { MOCK_CARD, mockFetchForPrintings } from './PrintingModal.test.helpers';
+
+/**
+ * Issue #138: Filter Finish Options Based on Available Finishes
+ *
+ * These tests verify that the finish selector only shows options that are
+ * actually available for a specific card printing based on Scryfall's finishes array.
+ *
+ * Test coverage:
+ * - Filter finish options based on printing.finishes array
+ * - Auto-select when only one finish is available
+ * - Handle missing/empty finishes data gracefully (fallback to all options)
+ * - Reset finish selection when changing printings
+ * - Maintain keyboard accessibility
+ * - Default priority: nonfoil > foil > etched
+ */
+describe('PrintingModal - Finish Filtering (Issue #138)', () => {
+	beforeEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	// ---------------------------------------------------------------------------
+	// Test Data: Printings with different finish availability
+	// ---------------------------------------------------------------------------
+	const PRINTING_NONFOIL_ONLY = {
+		id: 'nonfoil-only',
+		name: 'Test Card',
+		set: 'dom',
+		set_name: 'Dominaria',
+		collector_number: '100',
+		image_url: 'https://example.com/nonfoil.jpg',
+		released_at: '2018-04-27',
+		finishes: ['nonfoil']
+	};
+
+	const PRINTING_FOIL_ONLY = {
+		id: 'foil-only',
+		name: 'Test Card',
+		set: 'promo',
+		set_name: 'Promotional',
+		collector_number: 'P1',
+		image_url: 'https://example.com/foil.jpg',
+		released_at: '2020-01-01',
+		finishes: ['foil']
+	};
+
+	const PRINTING_BOTH_FINISHES = {
+		id: 'both-finishes',
+		name: 'Test Card',
+		set: 'znr',
+		set_name: 'Zendikar Rising',
+		collector_number: '42',
+		image_url: 'https://example.com/both.jpg',
+		released_at: '2020-09-25',
+		finishes: ['nonfoil', 'foil']
+	};
+
+	const PRINTING_ALL_FINISHES = {
+		id: 'all-finishes',
+		name: 'Test Card',
+		set: 'mh2',
+		set_name: 'Modern Horizons 2',
+		collector_number: '200',
+		image_url: 'https://example.com/all.jpg',
+		released_at: '2021-06-18',
+		finishes: ['nonfoil', 'foil', 'etched']
+	};
+
+	const PRINTING_NO_FINISHES = {
+		id: 'no-finishes',
+		name: 'Old Card',
+		set: 'lea',
+		set_name: 'Alpha',
+		collector_number: '1',
+		image_url: 'https://example.com/old.jpg',
+		released_at: '1993-08-05'
+		// No finishes array (older data)
+	};
+
+	const PRINTING_EMPTY_FINISHES = {
+		id: 'empty-finishes',
+		name: 'Test Card',
+		set: 'tst',
+		set_name: 'Test Set',
+		collector_number: '99',
+		image_url: 'https://example.com/empty.jpg',
+		released_at: '2020-01-01',
+		finishes: []
+	};
+
+	// ---------------------------------------------------------------------------
+	// Unit Tests: Filter finish options based on available finishes
+	// ---------------------------------------------------------------------------
+	describe('Filter finish options', () => {
+		it('should only show "Nonfoil" option when printing has finishes: ["nonfoil"]', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_NONFOIL_ONLY] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			});
+
+			// Should only have Nonfoil option visible
+			expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			expect(screen.queryByText('Foil')).not.toBeInTheDocument();
+			expect(screen.queryByText('Etched')).not.toBeInTheDocument();
+
+			// Should have only 1 radio button
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(1);
+			expect((radios[0] as HTMLInputElement).value).toBe('nonfoil');
+		});
+
+		it('should only show "Foil" option when printing has finishes: ["foil"]', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_FOIL_ONLY] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Foil')).toBeInTheDocument();
+			});
+
+			// Should only have Foil option visible
+			expect(screen.queryByText('Nonfoil')).not.toBeInTheDocument();
+			expect(screen.getByText('Foil')).toBeInTheDocument();
+			expect(screen.queryByText('Etched')).not.toBeInTheDocument();
+
+			// Should have only 1 radio button
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(1);
+			expect((radios[0] as HTMLInputElement).value).toBe('foil');
+		});
+
+		it('should show "Nonfoil" and "Foil" when printing has finishes: ["nonfoil", "foil"]', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_BOTH_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			});
+
+			// Should have Nonfoil and Foil options
+			expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			expect(screen.getByText('Foil')).toBeInTheDocument();
+			expect(screen.queryByText('Etched')).not.toBeInTheDocument();
+
+			// Should have 2 radio buttons
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(2);
+		});
+
+		it('should show all three options when printing has finishes: ["nonfoil", "foil", "etched"]', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_ALL_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			});
+
+			// Should have all three options
+			expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			expect(screen.getByText('Foil')).toBeInTheDocument();
+			expect(screen.getByText('Etched')).toBeInTheDocument();
+
+			// Should have 3 radio buttons
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(3);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Unit Tests: Auto-select when only one finish is available
+	// ---------------------------------------------------------------------------
+	describe('Auto-select single finish option', () => {
+		it('should auto-select "nonfoil" when it is the only available finish', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_NONFOIL_ONLY] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const radios = screen.getAllByRole('radio');
+				expect(radios.length).toBe(1);
+			});
+
+			const nonfoilRadio = screen.getByRole('radio', { name: /nonfoil/i });
+			expect(nonfoilRadio).toBeChecked();
+		});
+
+		it('should auto-select "foil" when it is the only available finish', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_FOIL_ONLY] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const radios = screen.getAllByRole('radio');
+				expect(radios.length).toBe(1);
+			});
+
+			const foilRadio = screen.getByRole('radio', { name: /foil/i });
+			expect(foilRadio).toBeChecked();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Unit Tests: Handle missing/empty finishes data gracefully
+	// ---------------------------------------------------------------------------
+	describe('Handle missing finishes data', () => {
+		it('should show all three finish options when finishes array is missing', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_NO_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			});
+
+			// Should show all three options as fallback
+			expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			expect(screen.getByText('Foil')).toBeInTheDocument();
+			expect(screen.getByText('Etched')).toBeInTheDocument();
+
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(3);
+		});
+
+		it('should show all three finish options when finishes array is empty', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_EMPTY_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			});
+
+			// Should show all three options as fallback
+			expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			expect(screen.getByText('Foil')).toBeInTheDocument();
+			expect(screen.getByText('Etched')).toBeInTheDocument();
+
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(3);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Unit Tests: Reset finish selection when changing printings
+	// ---------------------------------------------------------------------------
+	describe('Reset finish when changing printings', () => {
+		it('should reset finish when switching from nonfoil-only to foil-only printing', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () =>
+							Promise.resolve({ printings: [PRINTING_NONFOIL_ONLY, PRINTING_FOIL_ONLY] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+
+			// Select first printing (nonfoil only)
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const nonfoilRadio = screen.getByRole('radio', { name: /nonfoil/i });
+				expect(nonfoilRadio).toBeChecked();
+			});
+
+			// Switch to second printing (foil only)
+			await fireEvent.mouseEnter(printingItems[1]);
+
+			await waitFor(() => {
+				const foilRadio = screen.getByRole('radio', { name: /foil/i });
+				expect(foilRadio).toBeChecked();
+			});
+
+			// Should not show nonfoil anymore
+			expect(screen.queryByText('Nonfoil')).not.toBeInTheDocument();
+			expect(screen.getByText('Foil')).toBeInTheDocument();
+		});
+
+		it('should default to nonfoil when switching to printing with multiple finishes', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () =>
+							Promise.resolve({ printings: [PRINTING_FOIL_ONLY, PRINTING_BOTH_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+
+			// Select first printing (foil only)
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const foilRadio = screen.getByRole('radio', { name: /foil/i });
+				expect(foilRadio).toBeChecked();
+			});
+
+			// Switch to second printing (nonfoil and foil)
+			await fireEvent.mouseEnter(printingItems[1]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Nonfoil')).toBeInTheDocument();
+			});
+
+			// Should default to nonfoil (priority: nonfoil > foil > etched)
+			const nonfoilRadio = screen.getByRole('radio', { name: /nonfoil/i });
+			expect(nonfoilRadio).toBeChecked();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Unit Tests: Default selection priority (nonfoil > foil > etched)
+	// ---------------------------------------------------------------------------
+	describe('Default selection priority', () => {
+		it('should default to "nonfoil" when both nonfoil and foil are available', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_BOTH_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const nonfoilRadio = screen.getByRole('radio', { name: /nonfoil/i });
+				expect(nonfoilRadio).toBeChecked();
+			});
+		});
+
+		it('should default to "nonfoil" when all three finishes are available', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_ALL_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const nonfoilRadio = screen.getByRole('radio', { name: /nonfoil/i });
+				expect(nonfoilRadio).toBeChecked();
+			});
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Integration Tests: Form submission with filtered finishes
+	// ---------------------------------------------------------------------------
+	describe('Form submission with filtered finishes', () => {
+		it('should submit correct finish when only one option is available', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_FOIL_ONLY] })
+					});
+				}
+				if (typeof url === 'string' && url.includes('/api/inventory') && opts?.method === 'POST') {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ card_id: 'foil-only', quantity: 1, finish: 'foil' })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				expect(screen.getByLabelText(/price/i)).toBeInTheDocument();
+			});
+
+			// Fill in price
+			const priceInput = screen.getByLabelText(/price/i);
+			await fireEvent.input(priceInput, { target: { value: '10.00' } });
+
+			// Submit
+			const addButton = screen.getByRole('button', { name: /add to inventory/i });
+			await fireEvent.click(addButton);
+
+			// Verify correct finish was submitted
+			await waitFor(() => {
+				expect(mockFetch).toHaveBeenCalledWith(
+					expect.stringContaining('/api/inventory'),
+					expect.objectContaining({
+						method: 'POST',
+						body: expect.stringContaining('"finish":"foil"')
+					})
+				);
+			});
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Accessibility Tests: Keyboard navigation with filtered options
+	// ---------------------------------------------------------------------------
+	describe('Keyboard accessibility with filtered options', () => {
+		it('should allow keyboard navigation through available finish options only', async () => {
+			const mockFetch = vi.fn().mockImplementation((url: string) => {
+				if (typeof url === 'string' && url.includes('/printings')) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ printings: [PRINTING_BOTH_FINISHES] })
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			});
+			vi.stubGlobal('fetch', mockFetch);
+
+			render(PrintingModal, { props: { card: MOCK_CARD, open: true } });
+
+			await waitFor(() => {
+				expect(screen.getByTestId('printings-list')).toBeInTheDocument();
+			});
+
+			const printingItems = screen.getAllByTestId('printing-item');
+			await fireEvent.mouseEnter(printingItems[0]);
+
+			await waitFor(() => {
+				const radios = screen.getAllByRole('radio');
+				expect(radios.length).toBe(2);
+			});
+
+			// Should only have nonfoil and foil (no etched)
+			const radios = screen.getAllByRole('radio');
+			expect(radios.length).toBe(2);
+			expect((radios[0] as HTMLInputElement).value).toBe('nonfoil');
+			expect((radios[1] as HTMLInputElement).value).toBe('foil');
+
+			// Both should be keyboard accessible
+			expect(radios[0]).toHaveAttribute('type', 'radio');
+			expect(radios[1]).toHaveAttribute('type', 'radio');
+		});
+	});
+});

--- a/frontend/src/lib/components/PrintingModal.form.test.ts
+++ b/frontend/src/lib/components/PrintingModal.form.test.ts
@@ -186,7 +186,7 @@ describe('PrintingModal - Form', () => {
 			expect(languageSelect).toHaveValue('Japanese');
 		});
 
-		it('preserves form field values when selecting a different printing', async () => {
+		it('preserves price but resets finish when selecting a different printing (Issue #138)', async () => {
 			const mockFetch = mockFetchForPrintings();
 			vi.stubGlobal('fetch', mockFetch);
 
@@ -220,15 +220,16 @@ describe('PrintingModal - Form', () => {
 			await fireEvent.mouseEnter(printingItems[1]);
 
 			await waitFor(() => {
-				// Values should be preserved (not reset)
+				// Price should be preserved
 				const updatedPriceInput = screen.getByLabelText(/price/i) as HTMLInputElement;
 				expect(updatedPriceInput).toHaveValue(25.5);
 
+				// Finish should reset to default (nonfoil) per Issue #138
 				const updatedRadios = screen.getAllByRole('radio');
-				const updatedFoilRadio = updatedRadios.find(
-					(r) => (r as HTMLInputElement).value === 'foil'
+				const updatedNonfoilRadio = updatedRadios.find(
+					(r) => (r as HTMLInputElement).value === 'nonfoil'
 				);
-				expect(updatedFoilRadio).toBeChecked();
+				expect(updatedNonfoilRadio).toBeChecked();
 			});
 		});
 	});

--- a/frontend/src/lib/components/PrintingModal.segmented-control.test.ts
+++ b/frontend/src/lib/components/PrintingModal.segmented-control.test.ts
@@ -305,7 +305,7 @@ describe('PrintingModal - SegmentedControl for Finish Selection (Issue #136)', (
 	// Integration Tests: Selection Persistence
 	// ---------------------------------------------------------------------------
 	describe('Selection Persistence', () => {
-		it('should preserve finish selection when changing printings', async () => {
+		it('should reset finish selection to default when changing printings (Issue #138)', async () => {
 			const mockFetch = mockFetchForPrintings();
 			vi.stubGlobal('fetch', mockFetch);
 
@@ -337,13 +337,13 @@ describe('PrintingModal - SegmentedControl for Finish Selection (Issue #136)', (
 			// Change to second printing
 			await fireEvent.mouseEnter(printingItems[1]);
 
-			// Finish selection should still be foil
+			// Finish selection should reset to default (nonfoil) per Issue #138
 			await waitFor(() => {
 				const updatedRadios = screen.getAllByRole('radio');
-				const updatedFoilRadio = updatedRadios.find(
-					(radio) => (radio as HTMLInputElement).value === 'foil'
+				const updatedNonfoilRadio = updatedRadios.find(
+					(radio) => (radio as HTMLInputElement).value === 'nonfoil'
 				);
-				expect(updatedFoilRadio).toBeChecked();
+				expect(updatedNonfoilRadio).toBeChecked();
 			});
 		});
 

--- a/frontend/src/lib/components/PrintingModal.svelte
+++ b/frontend/src/lib/components/PrintingModal.svelte
@@ -20,6 +20,7 @@
 		collector_number: string;
 		image_url?: string;
 		released_at: string;
+		finishes?: string[];
 	}
 
 	interface Props {
@@ -85,6 +86,40 @@
 	let invalidField = $state<string | null>(null);
 	let validationToastMessage = $state('');
 	let showValidationToast = $state(false);
+
+	// Issue #138: Filter finish options based on available finishes for selected printing
+	// Derived value that returns available finishes for the selected printing
+	// Falls back to all options if finishes data is missing/empty
+	let availableFinishes = $derived.by(() => {
+		if (!selectedPrinting) return FINISH_OPTIONS;
+		if (!selectedPrinting.finishes || selectedPrinting.finishes.length === 0) {
+			return FINISH_OPTIONS;
+		}
+		return selectedPrinting.finishes;
+	});
+
+	// Helper function to get the default finish based on priority: nonfoil > foil > etched
+	function getDefaultFinish(finishes: string[]): string {
+		if (finishes.includes('nonfoil')) return 'nonfoil';
+		if (finishes.includes('foil')) return 'foil';
+		if (finishes.includes('etched')) return 'etched';
+		return 'nonfoil'; // Fallback
+	}
+
+	// Track previous printing to detect changes
+	let previousPrintingId: string | null = $state(null);
+
+	// Effect to reset finish selection when selected printing changes
+	$effect(() => {
+		if (selectedPrinting) {
+			// If printing changed (new printing selected)
+			if (previousPrintingId !== selectedPrinting.id) {
+				// Always reset to default finish when changing printings
+				finish = getDefaultFinish(availableFinishes);
+				previousPrintingId = selectedPrinting.id;
+			}
+		}
+	});
 
 	function isResponseSuccessful(response: Response): boolean {
 		// 304 Not Modified is considered successful - browser returns cached data automatically
@@ -362,36 +397,18 @@
 									<div class="form-group">
 										<label class="form-label">Finish</label>
 										<div class="finish-options" onclick={(e) => e.stopPropagation()}>
-											<label class="finish-option">
-												<input
-													type="radio"
-													name="finish"
-													value="nonfoil"
-													bind:group={finish}
-													checked={finish === 'nonfoil'}
-												/>
-												<span>Nonfoil</span>
-											</label>
-											<label class="finish-option">
-												<input
-													type="radio"
-													name="finish"
-													value="foil"
-													bind:group={finish}
-													checked={finish === 'foil'}
-												/>
-												<span>Foil</span>
-											</label>
-											<label class="finish-option">
-												<input
-													type="radio"
-													name="finish"
-													value="etched"
-													bind:group={finish}
-													checked={finish === 'etched'}
-												/>
-												<span>Etched</span>
-											</label>
+											{#each availableFinishes as finishOption}
+												<label class="finish-option">
+													<input
+														type="radio"
+														name="finish"
+														value={finishOption}
+														bind:group={finish}
+														checked={finish === finishOption}
+													/>
+													<span>{finishOption.charAt(0).toUpperCase() + finishOption.slice(1)}</span>
+												</label>
+											{/each}
 										</div>
 									</div>
 


### PR DESCRIPTION
## Summary
Implements Issue #138: Filter finish options in PrintingModal based on the available finishes for each card printing from Scryfall API.

### Backend Changes
- Added `finishes` array field to CardPrintingsService output
- Includes finishes data from Scryfall API response (e.g., `["nonfoil"]`, `["nonfoil", "foil"]`, `["nonfoil", "foil", "etched"]`)
- Handles missing finishes gracefully (returns nil for backward compatibility)
- Added comprehensive tests for finishes field handling

### Frontend Changes
- Updated Printing interface to include optional `finishes?: string[]`
- Implemented dynamic finish filtering based on available finishes
- Auto-selects finish when only one option is available
- Resets finish selection to default when changing printings (priority: nonfoil > foil > etched)
- Fallback to all options when finishes data is missing/empty
- Maintains keyboard accessibility with filtered options
- Added 14 new tests covering all filtering scenarios
- Updated 2 existing tests to reflect new reset behavior

### User Experience Improvements
- Users can only see and select finishes that are actually available for a card printing
- Prevents invalid finish combinations in inventory data
- Provides better user guidance by hiding unavailable options
- Maintains accessibility and keyboard navigation

### Test Coverage
- Backend: 25 tests passing (2 new tests for finishes)
- Frontend: 113 tests passing (14 new finish filtering tests)
- All existing tests updated and passing
- Comprehensive coverage of edge cases and error scenarios

### Implementation Approach
Followed TDD methodology:
1. **RED Phase**: Wrote failing tests for finishes array in backend and frontend
2. **GREEN Phase**: Implemented backend finishes field and frontend filtering logic
3. **REFACTOR Phase**: Cleaned up code, eliminated duplication, ensured DRY principles

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)