### PR TITLE
Fix logging test assertions to match JSON format

### DIFF
--- a/backend/test/jobs/cache_card_image_job_test.rb
+++ b/backend/test/jobs/cache_card_image_job_test.rb
@@ -103,8 +103,9 @@ class CacheCardImageJobTest < ActiveJob::TestCase
 
     Rails.logger = old_logger
 
-    assert log_output.string.include?("Successfully cached"), "Should log success"
-    assert log_output.string.include?("test-card-uuid"), "Should include card ID"
+    # Verify JSON log format for successful image download
+    assert_log_entry(log_output.string, event: "image_downloaded", card_id: "test-card-uuid")
+    assert_log_entry(log_output.string, event: "cache_completed", status: "success")
   end
 
   test "job logs when image is already cached" do
@@ -122,7 +123,9 @@ class CacheCardImageJobTest < ActiveJob::TestCase
 
     Rails.logger = old_logger
 
-    assert log_output.string.include?("already cached"), "Should log that image is already cached"
+    # Verify JSON log format for already cached image
+    assert_log_entry(log_output.string, event: "already_cached", card_id: "test-card-uuid")
+    assert_log_entry(log_output.string, event: "cache_completed", status: "success")
   end
 
   test "job handles nil image URL gracefully" do

--- a/backend/test/jobs/update_card_prices_job_test.rb
+++ b/backend/test/jobs/update_card_prices_job_test.rb
@@ -123,8 +123,9 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       UpdateCardPricesJob.perform_now(card_id)
     end
 
-    assert_match(/successfully updated/i, log_output)
-    assert_match(/#{card_id}/, log_output)
+    # Verify JSON log format for successful updates
+    assert_log_entry(log_output, event: "card_processed", card_id: card_id, success: true)
+    assert_log_entry(log_output, event: "price_update_completed", status: "success")
   end
 
   test "job logs error message on failure" do
@@ -147,8 +148,8 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       assert error_raised, "Expected an error to be raised"
     end
 
-    assert_match(/failed to update/i, log_output)
-    assert_match(/#{card_id}/, log_output)
+    # Verify JSON log format for errors
+    assert_log_entry(log_output, event: "error_occurred", card_id: card_id)
   end
 
   test "job handles non-existent card gracefully" do
@@ -224,7 +225,8 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       end
     end
 
-    assert_match(/card_id.*required/i, log_output)
+    # Verify JSON log format for validation error
+    assert_log_entry(log_output, event: "error_occurred")
   end
 
   test "job accepts nil to process all cards" do
@@ -487,9 +489,13 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       UpdateCardPricesJob.perform_now(nil)
     end
 
-    # Should log progress at 100 and 200 cards
-    assert_match(/Processed 100 cards/i, log_output)
-    assert_match(/Processed 200 cards/i, log_output)
+    # Verify JSON log format for progress updates at 100 and 200 cards
+    progress_logs = find_log_entries(log_output, event: "progress_update")
+    progress_100 = progress_logs.find { |log| log["cards_processed"] == 100 }
+    progress_200 = progress_logs.find { |log| log["cards_processed"] == 200 }
+
+    assert_not_nil progress_100, "Expected progress log at 100 cards"
+    assert_not_nil progress_200, "Expected progress log at 200 cards"
   end
 
   test "batch mode logs total execution time" do
@@ -507,9 +513,13 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       UpdateCardPricesJob.perform_now(nil)
     end
 
-    # Should log completion time
-    assert_match(/Completed price update job in .+ seconds/i, log_output)
-    assert_match(/Updated prices for \d+ cards/i, log_output)
+    # Verify JSON log format for completion event
+    assert_log_entry(log_output, event: "price_update_completed")
+
+    # Check that duration is logged
+    completion_logs = find_log_entries(log_output, event: "price_update_completed")
+    assert completion_logs.any? { |log| log["duration_seconds"].present? },
+           "Expected duration_seconds in completion log"
   end
 
   test "batch mode logs starting message with card count" do
@@ -527,7 +537,8 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       UpdateCardPricesJob.perform_now(nil)
     end
 
-    assert_match(/Starting batch price update for 1 unique cards/i, log_output)
+    # Verify JSON log format for batch start event
+    assert_log_entry(log_output, event: "price_update_started", mode: "batch")
   end
 
   test "batch mode continues processing after single card error" do
@@ -550,8 +561,10 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       end
     end
 
-    # Should log error but continue
-    assert_match(/Error processing card bad-card/i, log_output)
+    # Verify JSON log format for failed card processing
+    failed_card_logs = find_log_entries(log_output, event: "card_processed", card_id: "bad-card")
+    assert failed_card_logs.any? { |log| log["success"] == false },
+           "Expected card_processed event with success=false for bad-card"
 
     # Verify good cards were processed
     assert_not_nil CardPrice.latest_for("good-card-1")
@@ -588,11 +601,18 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
     # Should complete without timeout (less than 60 seconds for test)
     assert execution_time < 60, "Job took too long: #{execution_time} seconds"
 
+    # Verify JSON log format for batch processing
+    assert_log_entry(log_output, event: "price_update_started", mode: "batch")
+
     # Should log progress multiple times
-    assert_match(/Starting batch price update for 1000 unique cards/i, log_output)
-    assert_match(/Processed 100 cards/i, log_output)
-    assert_match(/Processed 500 cards/i, log_output)
-    assert_match(/Completed price update job/i, log_output)
+    progress_logs = find_log_entries(log_output, event: "progress_update")
+    progress_100 = progress_logs.find { |log| log["cards_processed"] == 100 }
+    progress_500 = progress_logs.find { |log| log["cards_processed"] == 500 }
+
+    assert_not_nil progress_100, "Expected progress log at 100 cards"
+    assert_not_nil progress_500, "Expected progress log at 500 cards"
+
+    assert_log_entry(log_output, event: "price_update_completed")
 
     # Verify all cards were processed
     assert_equal 1000, CardPrice.count
@@ -708,9 +728,14 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
       end
     end
 
-    # Should log alert detection
-    assert_match(/Detecting price changes for alerts/i, log_output)
-    assert_match(/Created 1 price alerts/i, log_output)
+    # Verify JSON log format for price alert detection
+    assert_log_entry(log_output, event: "detecting_price_changes")
+    assert_log_entry(log_output, event: "price_alerts_detected")
+
+    # Check that price_alerts_created count is logged
+    alert_logs = find_log_entries(log_output, event: "price_alerts_detected")
+    assert alert_logs.any? { |log| log["count"] == 1 },
+           "Expected price_alerts_detected event with count=1"
 
     # Verify alert was created correctly
     alert = PriceAlert.last
@@ -750,8 +775,8 @@ class UpdateCardPricesJobTest < ActiveJob::TestCase
         end
       end
 
-      # Should log error but not fail the job
-      assert_match(/Error detecting price changes/i, log_output)
+      # Verify JSON log format for price alert error
+      assert_log_entry(log_output, event: "error_occurred")
     end
   end
 end

--- a/backend/test/test_helper.rb
+++ b/backend/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "mocha/minitest"
+require "json"
 
 # Load VCR setup if present
 vcr_setup = File.expand_path("support/vcr_setup.rb", __dir__)
@@ -35,5 +36,70 @@ module ActiveSupport
     # fixtures :all
 
     # Add more helper methods to be used by all tests here...
+
+    # ---------------------------------------------------------------------------
+    # JSON log parsing helpers for structured logging tests
+    # ---------------------------------------------------------------------------
+
+    # Parse all JSON log entries from a log string
+    # Returns an array of parsed JSON objects (hashes)
+    def parse_json_logs(log_string)
+      log_string.split("\n").filter_map do |line|
+        # Skip empty lines
+        next if line.strip.empty?
+
+        # Extract JSON portion from log line
+        # Rails logger format: "I, [timestamp #pid]  LEVEL -- : {json}"
+        # We need to find the JSON object starting with {
+        json_start = line.index("{")
+        next unless json_start
+
+        json_portion = line[json_start..]
+
+        begin
+          ::JSON.parse(json_portion)
+        rescue ::JSON::ParserError
+          nil
+        end
+      end
+    end
+
+    # Find log entries matching specific criteria
+    # Returns array of matching log entries
+    #
+    # Example:
+    #   find_log_entries(logs, event: "image_downloaded", card_id: "test-123")
+    def find_log_entries(log_string, **criteria)
+      parsed_logs = parse_json_logs(log_string)
+
+      parsed_logs.select do |entry|
+        criteria.all? { |key, value| entry[key.to_s] == value.to_s }
+      end
+    end
+
+    # Assert that a JSON log entry exists with the given criteria
+    #
+    # Example:
+    #   assert_log_entry(logs, event: "cache_completed", status: "success")
+    def assert_log_entry(log_string, **criteria)
+      matches = find_log_entries(log_string, **criteria)
+
+      assert matches.any?,
+             "Expected to find log entry matching #{criteria.inspect}, " \
+             "but found none. Available logs:\n#{format_parsed_logs(log_string)}"
+    end
+
+    # Format parsed logs for easier debugging in test failures
+    def format_parsed_logs(log_string)
+      parsed_logs = parse_json_logs(log_string)
+
+      if parsed_logs.empty?
+        "No valid JSON log entries found. Raw logs:\n#{log_string}"
+      else
+        parsed_logs.map.with_index do |entry, i|
+          "  [#{i}] #{entry.inspect}"
+        end.join("\n")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
Updates test assertions to match the current structured JSON logging format. The application moved to JSON logging but tests were still expecting plain-text formats, causing 12+ test failures.

## Changes
- Added JSON log parsing helpers to `test_helper.rb` for reusable test utilities
- Updated `cache_card_image_job_test.rb` assertions (fixed 2 tests)
- Updated `update_card_prices_job_test.rb` assertions (fixed 8+ tests)

## Example
**Before (plain-text):**
```ruby
assert log_output.include?("Successfully cached")
```

**After (JSON):**
```ruby
assert_log_entry(log_output, event: "cache_completed", status: "success")
```

## Test Results
- ✅ All updated tests now pass
- ✅ No production code changes (functionality already working)
- ✅ JSON helpers available for future test maintenance

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)