### PR TITLE
fix: improve test isolation by clearing records in setup (fixes #145)

### DIFF
--- a/backend/test/models/image_cache_execution_test.rb
+++ b/backend/test/models/image_cache_execution_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class ImageCacheExecutionTest < ActiveSupport::TestCase
+  def setup
+    # Clear all records to ensure test isolation
+    ImageCacheExecution.delete_all
+  end
+
   # ---------------------------------------------------------------------------
   # Presence validations
   # ---------------------------------------------------------------------------

--- a/backend/test/models/price_update_execution_test.rb
+++ b/backend/test/models/price_update_execution_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class PriceUpdateExecutionTest < ActiveSupport::TestCase
+  def setup
+    # Clear all records to ensure test isolation
+    PriceUpdateExecution.delete_all
+  end
+
   # ---------------------------------------------------------------------------
   # Presence validations
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Added setup methods to PriceUpdateExecutionTest and ImageCacheExecutionTest to clear all records before each test runs. This ensures proper test isolation and prevents data pollution from previous test runs.

Root cause:
- Tests were failing due to leftover records from previous test executions
- "can order by most recent first" tests expected specific record positions
- Without cleanup, database contained records from earlier tests

Solution:
- Added setup method calling delete_all before each test
- Ensures each test runs with a clean slate
- Tests now pass consistently regardless of execution order

Test results:
- All 35 PriceUpdateExecution tests passing
- All 32 ImageCacheExecution tests passing
- Verified with multiple random seeds (1, 9999, 5555)