### PR TITLE
Fix issue #151 - Set up recurring tasks in jobs:stats test

### DIFF
--- a/backend/test/rake/jobs_rake_test.rb
+++ b/backend/test/rake/jobs_rake_test.rb
@@ -11,11 +11,15 @@ class JobsRakeTest < ActiveSupport::TestCase
     # Clear any existing jobs
     SolidQueue::Job.where(class_name: "ScrapeEdhrecCommandersJob").delete_all
     SolidQueue::Job.where(class_name: "UpdateCardPricesJob").delete_all
+
+    # Clear any existing recurring tasks
+    SolidQueue::RecurringTask.delete_all
   end
 
   def teardown
     # Clean up
     SolidQueue::Job.delete_all
+    SolidQueue::RecurringTask.delete_all
   end
 
   # ============================================================================
@@ -61,6 +65,21 @@ class JobsRakeTest < ActiveSupport::TestCase
   end
 
   test "stats rake task shows enhanced information" do
+    # Create recurring tasks for testing (following pattern from job_monitoring_test.rb)
+    SolidQueue::RecurringTask.create!(
+      key: "weekly_commander_scrape",
+      schedule: "every sunday at 8am",
+      class_name: "ScrapeEdhrecCommandersJob",
+      queue_name: "default"
+    )
+
+    SolidQueue::RecurringTask.create!(
+      key: "daily_price_update",
+      schedule: "every day at 7am",
+      class_name: "UpdateCardPricesJob",
+      queue_name: "default"
+    )
+
     # Create some execution history
     ScraperExecution.create!(
       started_at: 1.day.ago,


### PR DESCRIPTION
## Summary
- Fixes the failing `JobsRakeTest#test_stats_rake_task_shows_enhanced_information` test by properly setting up recurring tasks in the test environment
- Added `SolidQueue::RecurringTask` creation in test setup following the pattern from `job_monitoring_test.rb`
- Ensured proper cleanup in teardown to maintain test isolation

## Root Cause
The test expected the `rails jobs:stats` rake task to display recurring task information including "next run" times, "last run" status, "avg duration" statistics, and execution counts. However, no recurring tasks existed in the test database, causing the test to fail.

## Changes
1. Added `SolidQueue::RecurringTask.delete_all` to both setup and teardown methods
2. Created two recurring tasks in the test:
   - `weekly_commander_scrape` - scheduled "every sunday at 8am"
   - `daily_price_update` - scheduled "every day at 7am"
3. Both tasks match production configuration for realistic testing

## Test Results
- ✅ All rake tests passing (4 runs, 20 assertions, 0 failures)
- ✅ Job monitoring tests still passing (18 runs, 31 assertions, 0 failures)
- ✅ Test output now contains expected information: "next run", "last run", "avg duration", and "executions:"

## Test Plan
- [x] Run the specific failing test: `rails test test/rake/jobs_rake_test.rb:63`
- [x] Run all rake tests to ensure no regressions
- [x] Run job monitoring tests to verify the pattern we followed still works
- [x] Verify test cleanup works properly (recurring tasks are cleaned up between tests)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)