### PR TITLE
Fix SearchService multi-term OR logic (fixes #191)

### DIFF
--- a/backend/app/services/search_service.rb
+++ b/backend/app/services/search_service.rb
@@ -36,12 +36,25 @@ class SearchService
     "search:decklists:#{normalized_query}"
   end
 
+  # Builds a tsquery string with OR logic for multiple terms
+  # Example: "sol vault" => "sol | vault"
+  def build_or_tsquery(query)
+    terms = query.strip.split(/\s+/).map(&:strip).reject(&:empty?)
+    return "" if terms.empty?
+
+    # Join terms with | for OR logic
+    terms.join(" | ")
+  end
+
   def perform_search
     # Use PostgreSQL full-text search on the vector column
+    # Convert query to OR logic: split terms and join with |
+    tsquery = build_or_tsquery(@query)
     sanitized_query = ActiveRecord::Base.connection.quote(@query)
+
     decklists = Decklist
       .joins(:commander)
-      .where("decklists.vector @@ plainto_tsquery('english', ?)", @query)
+      .where("decklists.vector @@ to_tsquery('english', ?)", tsquery)
       .includes(:commander, :partner)
       .select("decklists.*, ts_rank(decklists.vector, plainto_tsquery('english', #{sanitized_query})) AS search_rank")
       .order("search_rank DESC")


### PR DESCRIPTION
## Summary

- Fixed SearchService to use OR logic instead of AND logic for multi-term searches
- Verified Issue #193 (ScryfallCardResolver logging) already has passing tests

## Changes

### Issue #191 - SearchService Multi-Term OR Logic ✅

**Problem**: Search using multiple terms (e.g., "sol vault") was using AND logic, requiring all terms to match within the same card name. This prevented finding cards that matched different terms.

**Solution**: 
- Changed from `plainto_tsquery` (AND logic) to `to_tsquery` with OR operators
- Added `build_or_tsquery` helper method to split terms and join with `|`
- Now "sol vault" finds both "Sol Ring" (matches "sol") AND "Mana Vault" (matches "vault")

**Test Coverage**: `test_multiple_search_terms_use_OR_logic` now passes

### Issue #193 - ScryfallCardResolver Logging ℹ️

**Status**: Tests already passing - no code changes needed

Both required tests pass successfully:
- `test_resolve_cards_logs_warnings_for_unresolved_cards` ✓
- `test_resolve_cards_logs_rate_limit_events` ✓

The logging functionality was already correctly implemented:
- Unresolved card warnings use `Rails.logger.warn` with proper formatting
- Rate limit events log at WARN level with backoff information

[See issue comment for details](https://github.com/cobaltroad/mtg-inventory/issues/193#issuecomment-3905286861)

## Test Results

All tests passing:
```
29 runs, 63 assertions, 0 failures, 0 errors, 0 skips
```

### SearchService Tests
- ✅ `test_multiple_search_terms_use_OR_logic` - Now passes with OR logic
- ✅ All 13 SearchService tests pass

### ScryfallCardResolver Tests  
- ✅ All 16 tests pass including both logging tests
- ✅ 37 assertions pass

## Test Plan

- [x] Run SearchService test suite - all tests pass
- [x] Run ScryfallCardResolver test suite - all tests pass
- [x] Verify multi-term search returns expected results
- [x] Verify logging tests validate WARN level messages
- [x] Manual verification: Search "sol vault" returns both Sol Ring and Mana Vault matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)