### PR TITLE
Fix X icon visibility in PriceAlertWidget dismiss button

### DIFF
--- a/frontend/src/lib/components/PriceAlertWidget.svelte
+++ b/frontend/src/lib/components/PriceAlertWidget.svelte
@@ -164,12 +164,12 @@
 							<!-- Dismiss button -->
 							<button
 								type="button"
-								class="btn-icon rounded-md transition-all bg-surface-300 text-surface-900 hover:bg-error-500 hover:text-white dark:bg-surface-700 dark:text-surface-100 dark:hover:bg-error-500"
+								class="p-1 rounded-md transition-colors bg-surface-300 hover:bg-error-500 dark:bg-surface-700 dark:hover:bg-error-500"
 								onclick={() => dismissAlert(alert.id)}
 								aria-label={`Dismiss ${alert.card_name || 'alert'}`}
 								title="Dismiss this alert"
 							>
-								<X size={20} />
+								<X class="text-surface-900 hover:text-white dark:text-surface-100" size={16} />
 							</button>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

- Fixes issue #213 - The X icon in the PriceAlertWidget dismiss button was not visible
- Replaces `btn-icon` class with standard Tailwind padding (`p-1`) to resolve rendering issue
- Adds explicit color classes to the X icon component for proper visibility in both light/dark modes
- Reduces button size for better proportionality

## Changes

- Changed button class from `btn-icon` to `p-1 rounded-md` 
- Added color classes to X icon: `text-surface-900 hover:text-white dark:text-surface-100`
- Reduced icon size from 20 to 16

## Testing

- Verified X icon is visible in default state (gray background, dark icon)
- Verified X icon turns white on hover (red background)
- Verified works in both light and dark modes