### PR TITLE
Implement mobile-responsive inventory (Issue #42)

### DIFF
--- a/frontend/src/lib/components/ColorFilter.svelte
+++ b/frontend/src/lib/components/ColorFilter.svelte
@@ -319,21 +319,36 @@
 	/* Responsive adjustments */
 	@media (max-width: 640px) {
 		.color-buttons {
-			gap: 0.375rem;
+			gap: 0.5rem;
 		}
 
 		.color-button {
-			width: 2.25rem;
-			height: 2.25rem;
+			width: 2.75rem;
+			height: 2.75rem;
+			min-width: 2.75rem;
+			min-height: 2.75rem;
 		}
 
 		.mana-symbol {
-			font-size: 1rem;
+			font-size: 1.125rem;
+		}
+
+		.divider {
+			display: none;
 		}
 
 		.special-filter {
-			min-width: 4rem;
-			height: 2.25rem;
+			min-width: 2.75rem;
+			height: 2.75rem;
+			min-height: 2.75rem;
+			border-radius: 50%;
+		}
+
+		.clear-all-button {
+			width: 2.75rem;
+			height: 2.75rem;
+			min-width: 2.75rem;
+			min-height: 2.75rem;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar.svelte
@@ -260,4 +260,28 @@
 	:global(.dark) .no-results {
 		color: #9ca3af;
 	}
+
+	@media (max-width: 640px) {
+		.filter-container {
+			width: 100%;
+		}
+
+		.filter-button {
+			width: 100%;
+			justify-content: center;
+			min-height: 44px;
+		}
+
+		.dropdown {
+			width: 100%;
+			left: 0;
+			right: 0;
+			max-height: 60vh;
+		}
+
+		.set-option {
+			padding: 1rem 0.75rem;
+			min-height: 44px;
+		}
+	}
 </style>

--- a/frontend/src/lib/components/InventoryTable.svelte
+++ b/frontend/src/lib/components/InventoryTable.svelte
@@ -154,7 +154,7 @@
 					<th>Image</th>
 					<th>Card Name</th>
 					<th>Quantity</th>
-					<th>Value</th>
+					<th class="desktop-only">Value</th>
 					<th>Details</th>
 					<th>Actions</th>
 				</tr>
@@ -162,7 +162,7 @@
 			<tbody>
 				{#each localItems as item (item.id)}
 					<tr>
-						<td>
+						<td data-label="Image">
 							<div class="image-cell">
 								{#if imageStates[item.id]?.error}
 									<div class="image-placeholder error">No image</div>
@@ -182,7 +182,7 @@
 								{/if}
 							</div>
 						</td>
-						<td>
+						<td data-label="Card Name">
 							<div class="card-name-cell">
 								<span class="font-beleren card-name">{item.card_name}</span>
 								<span class="collector-number">
@@ -194,18 +194,23 @@
 								</span>
 							</div>
 						</td>
-						<td>
-							<QuantityEditor
-								initialQuantity={item.quantity}
-								onSave={(newQuantity) => handleQuantityUpdate(item, newQuantity)}
-							/>
+						<td data-label="Quantity">
+							<div class="quantity-cell">
+								<QuantityEditor
+									initialQuantity={item.quantity}
+									onSave={(newQuantity) => handleQuantityUpdate(item, newQuantity)}
+								/>
+								<span class="price-display-mobile">
+									{formatCurrency(item.unit_price_cents, item.total_price_cents, item.quantity)}
+								</span>
+							</div>
 						</td>
-						<td>
+						<td data-label="Value" class="desktop-only">
 							<div class="price-cell">
 								{formatCurrency(item.unit_price_cents, item.total_price_cents, item.quantity)}
 							</div>
 						</td>
-						<td>
+						<td data-label="Details">
 							<div class="details-cell">
 								{#if item.finish}
 									<span class="detail-badge">{capitalizeFirstLetter(item.finish)}</span>
@@ -219,7 +224,7 @@
 								{/if}
 							</div>
 						</td>
-						<td>
+						<td data-label="Actions">
 							<button
 								class="remove-btn"
 								onclick={() => showRemoveConfirmation(item.id)}
@@ -491,7 +496,28 @@
 		white-space: nowrap;
 	}
 
+	.quantity-cell {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.5rem;
+	}
+
+	.price-display {
+		font-size: 0.875rem;
+		color: #111827;
+		font-weight: 500;
+	}
+
+	.price-display-mobile {
+		display: none;
+	}
+
 	:global(.dark) .price-cell {
+		color: #f9fafb;
+	}
+
+	:global(.dark) .price-display {
 		color: #f9fafb;
 	}
 
@@ -544,13 +570,136 @@
 	}
 
 	@media (max-width: 768px) {
+		.desktop-only {
+			display: none;
+		}
+
+		.desktop-only::before {
+			display: none;
+		}
+
 		.table-container {
 			font-size: 0.875rem;
 		}
 
+		.inventory-table {
+			display: block;
+		}
+
+		.inventory-table thead {
+			display: none;
+		}
+
+		.inventory-table tbody {
+			display: flex;
+			flex-direction: column;
+			gap: 1rem;
+			padding: 0.5rem;
+		}
+
+		.inventory-table tbody tr {
+			display: flex;
+			flex-direction: column;
+			background: white;
+			border: 1px solid #e5e7eb;
+			border-radius: 0.5rem;
+			padding: 1rem;
+			box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+		}
+
+		:global(.dark) .inventory-table tbody tr {
+			background: #1f2937;
+			border-color: #374151;
+		}
+
+		.inventory-table tbody tr:hover {
+			background: transparent;
+		}
+
+		.inventory-table td {
+			padding: 0.25rem 0;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			border: none;
+		}
+
+		.inventory-table td::before {
+			content: attr(data-label);
+			font-weight: 600;
+			color: #6b7280;
+			font-size: 0.75rem;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		:global(.dark) .inventory-table td::before {
+			color: #9ca3af;
+		}
+
 		.image-cell {
-			width: 60px;
-			height: 84px;
+			width: 100px;
+			height: 140px;
+			margin: 0 auto 0.75rem;
+		}
+
+		.card-name-cell {
+			flex-direction: row;
+			flex-wrap: wrap;
+			gap: 0.5rem;
+			justify-content: center;
+			text-align: center;
+		}
+
+		.card-name {
+			font-size: 1rem;
+			width: 100%;
+			text-align: center;
+		}
+
+		.collector-number {
+			font-size: 0.875rem;
+			width: 100%;
+			text-align: center;
+		}
+
+		.quantity-cell {
+			width: 100%;
+			align-items: center;
+			gap: 0.5rem;
+		}
+
+		.price-display {
+			display: none;
+		}
+
+		.price-display-mobile {
+			display: inline;
+			font-size: 1rem;
+			font-weight: 600;
+		}
+
+		:global(.dark) .price-display-mobile {
+			color: #f9fafb;
+		}
+
+		.price-cell {
+			display: none;
+		}
+
+		.details-cell {
+			flex-direction: row;
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: 0.5rem;
+		}
+
+		.remove-btn {
+			width: 100%;
+			justify-content: center;
+			padding: 0.75rem;
+			margin-top: 0.5rem;
+			min-height: 44px;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/QuantityEditor.svelte
+++ b/frontend/src/lib/components/QuantityEditor.svelte
@@ -289,4 +289,40 @@
 		appearance: textfield;
 		-moz-appearance: textfield;
 	}
+
+	@media (max-width: 640px) {
+		.quantity-display {
+			min-width: 4.5rem;
+			padding: 0.625rem 1rem;
+			font-size: 1rem;
+			min-height: 44px;
+		}
+
+		.quantity-value {
+			font-size: 1rem;
+		}
+
+		.quantity-input {
+			width: 5rem;
+			padding: 0.625rem 0.75rem;
+			font-size: 1rem;
+			min-height: 44px;
+		}
+
+		.button-group {
+			gap: 0.5rem;
+		}
+
+		.icon-btn {
+			width: 2.75rem;
+			height: 2.75rem;
+			min-width: 2.75rem;
+			min-height: 2.75rem;
+		}
+
+		.icon-btn :global(svg) {
+			width: 20px;
+			height: 20px;
+		}
+	}
 </style>

--- a/frontend/src/lib/components/RemoveConfirmation.svelte
+++ b/frontend/src/lib/components/RemoveConfirmation.svelte
@@ -315,6 +315,15 @@
 
 		.btn {
 			width: 100%;
+			min-height: 44px;
+			font-size: 1rem;
+		}
+
+		.close-btn {
+			width: 2.75rem;
+			height: 2.75rem;
+			min-width: 2.75rem;
+			min-height: 2.75rem;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -271,6 +271,13 @@
 		border-top: 1px solid rgb(229 231 235);
 	}
 
+	/* Hide mode toggle on mobile */
+	@media (max-width: 768px) {
+		.mode-toggle-wrapper {
+			display: none;
+		}
+	}
+
 	/* In rail mode, adjust padding for centered layout */
 	:global(.navigation-rail) .mode-toggle-wrapper {
 		padding: 1rem 0;

--- a/frontend/src/lib/components/SortDropdown.svelte
+++ b/frontend/src/lib/components/SortDropdown.svelte
@@ -102,4 +102,21 @@
 	:global(.dark) .sort-select:focus {
 		border-color: #60a5fa;
 	}
+
+	@media (max-width: 640px) {
+		.sort-dropdown {
+			width: 100%;
+		}
+
+		.sort-label {
+			display: none;
+		}
+
+		.sort-select {
+			width: 100%;
+			padding: 0.75rem 2.5rem 0.75rem 0.75rem;
+			font-size: 1rem;
+			min-height: 44px;
+		}
+	}
 </style>

--- a/frontend/src/routes/inventory/+page.svelte
+++ b/frontend/src/routes/inventory/+page.svelte
@@ -629,9 +629,12 @@
 	}
 
 	@media (max-width: 768px) {
-		.filter-sort-row {
-			flex-direction: column;
-			align-items: stretch;
+		.inventory-page {
+			padding: 1rem 0.75rem;
+		}
+
+		.page-header {
+			margin-bottom: 1rem;
 		}
 
 		.header-content {
@@ -642,11 +645,54 @@
 		.search-btn {
 			width: 100%;
 			justify-content: center;
+			min-height: 44px;
+			font-size: 1rem;
+		}
+
+		.page-title {
+			font-size: 1.5rem;
+		}
+
+		.item-count {
+			font-size: 0.875rem;
+		}
+
+		.controls-bar {
+			margin-bottom: 1rem;
+		}
+
+		.filter-sort-row {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.filters-group {
+			width: 100%;
+		}
+
+		.no-results {
+			padding: 3rem 1.5rem;
+		}
+
+		.no-results p {
+			font-size: 1rem;
 		}
 
 		.pagination-container {
 			flex-direction: column;
 			align-items: stretch;
+			margin-top: 1.5rem;
+		}
+
+		.page-size-label {
+			justify-content: center;
+			font-size: 0.875rem;
+		}
+
+		.page-size-select {
+			padding: 0.625rem 2.5rem 0.625rem 0.75rem;
+			font-size: 1rem;
+			min-height: 44px;
 		}
 
 		.pagination-nav {


### PR DESCRIPTION
- InventoryTable: single-column card layout on mobile with combined quantity/price
- ColorFilter: circular buttons stay circular on mobile (44px touch targets)
- FilterBar: full-width dropdown on mobile with 44px touch targets
- QuantityEditor: larger buttons (44px) for mobile
- RemoveConfirmation: full-width buttons (44px) for mobile
- SortDropdown: full-width on mobile
- Sidebar: hide collapse button on mobile, use hamburger instead
- Page-level: padding and layout adjustments for mobile

Also:
- Combined quantity and value into single row on mobile
- Hide Value column header on mobile (desktop-only class)
- Price displays inline with quantity editor on mobile